### PR TITLE
change link prefix so we can browse on new subdomain

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -241,7 +241,7 @@ module.exports = function(eleventyConfig) {
     // Leading or trailing slashes are all normalized away, so don’t worry about it.
     // If you don’t have a subdirectory, use "" or "/" (they do the same thing)
     // This is only used for URLs (it does not affect your file structure)
-    pathPrefix: (process.env.NODE_ENV == 'production' ? "/covid19.ca.gov-site-eng-playbook/" : "/"),
+    pathPrefix: "/",
     markdownTemplateEngine: "liquid",
     htmlTemplateEngine: "njk",
     dataTemplateEngine: "njk",


### PR DESCRIPTION
Site will then be browsable on teamdocs.covid19.ca.gov